### PR TITLE
[FEAT] 동아리 랭킹 기능을 위한 동아리 구현

### DIFF
--- a/src/main/java/org/sopt/collaboration/domain/club/controller/ClubController.java
+++ b/src/main/java/org/sopt/collaboration/domain/club/controller/ClubController.java
@@ -1,0 +1,23 @@
+package org.sopt.collaboration.domain.club.controller;
+
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.collaboration.domain.club.dto.ClubDto;
+import org.sopt.collaboration.domain.club.service.ClubService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class ClubController {
+    private final ClubService clubService;
+
+    @GetMapping("/club")
+    public ResponseEntity<List<ClubDto>> getClub(){
+        List<ClubDto> club = clubService.getAllClubs();
+        return ResponseEntity.ok(club);
+    }
+}

--- a/src/main/java/org/sopt/collaboration/domain/club/controller/ClubController.java
+++ b/src/main/java/org/sopt/collaboration/domain/club/controller/ClubController.java
@@ -16,8 +16,14 @@ public class ClubController {
     private final ClubService clubService;
 
     @GetMapping("/club")
-    public ResponseEntity<List<ClubDto>> getClub(){
-        List<ClubDto> club = clubService.getAllClubs();
+    public ResponseEntity<List<ClubDto>> getClubsByLikes(){
+        List<ClubDto> club = clubService.getClubsByLikesDesc();
         return ResponseEntity.ok(club);
+    }
+
+    @GetMapping("/club/all")
+    public ResponseEntity<List<ClubDto>> getClub(){
+        List<ClubDto> clubAll = clubService.getAllClubs();
+        return ResponseEntity.ok(clubAll);
     }
 }

--- a/src/main/java/org/sopt/collaboration/domain/club/controller/ClubController.java
+++ b/src/main/java/org/sopt/collaboration/domain/club/controller/ClubController.java
@@ -20,10 +20,4 @@ public class ClubController {
         List<ClubDto> club = clubService.getClubsByLikesDesc();
         return ResponseEntity.ok(club);
     }
-
-    @GetMapping("/club/all")
-    public ResponseEntity<List<ClubDto>> getClub(){
-        List<ClubDto> clubAll = clubService.getAllClubs();
-        return ResponseEntity.ok(clubAll);
-    }
 }

--- a/src/main/java/org/sopt/collaboration/domain/club/dto/ClubDto.java
+++ b/src/main/java/org/sopt/collaboration/domain/club/dto/ClubDto.java
@@ -1,0 +1,34 @@
+package org.sopt.collaboration.domain.club.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.collaboration.domain.club.entity.Club;
+import org.sopt.collaboration.domain.club.entity.enums.ClubCategory;
+import org.sopt.collaboration.domain.club.entity.enums.ClubDay;
+import org.sopt.collaboration.domain.club.entity.enums.ClubRegion;
+
+@Getter
+@NoArgsConstructor
+public class ClubDto {
+    private Long id;
+    private String clubName;
+    private String clubIntroduce;
+    private String clubImage;
+    private ClubCategory category;
+    private ClubRegion region;
+    private ClubDay clubDay;
+    private int likeCount;
+
+
+    // DTO 변환용 생성자
+    public ClubDto(Club club) {
+        this.id = club.getId();
+        this.clubName = club.getName();
+        this.clubIntroduce = club.getIntroduce();
+        this.clubImage = club.getImage();
+        this.category = club.getCategory();
+        this.region = club.getRegion();
+        this.clubDay = club.getClubDay();
+        this.likeCount = club.getLikeCount();
+    }
+}

--- a/src/main/java/org/sopt/collaboration/domain/club/dto/ClubDto.java
+++ b/src/main/java/org/sopt/collaboration/domain/club/dto/ClubDto.java
@@ -22,13 +22,8 @@ public class ClubDto {
 
     // DTO 변환용 생성자
     public ClubDto(Club club) {
-        this.id = club.getId();
         this.clubName = club.getName();
         this.clubIntroduce = club.getIntroduce();
         this.clubImage = club.getImage();
-        this.category = club.getCategory();
-        this.region = club.getRegion();
-        this.clubDay = club.getClubDay();
-        this.likeCount = club.getLikeCount();
     }
 }

--- a/src/main/java/org/sopt/collaboration/domain/club/repository/ClubRepository.java
+++ b/src/main/java/org/sopt/collaboration/domain/club/repository/ClubRepository.java
@@ -1,0 +1,9 @@
+package org.sopt.collaboration.domain.club.repository;
+
+import org.sopt.collaboration.domain.club.entity.Club;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ClubRepository extends JpaRepository<Club, Long> {
+}

--- a/src/main/java/org/sopt/collaboration/domain/club/repository/ClubRepository.java
+++ b/src/main/java/org/sopt/collaboration/domain/club/repository/ClubRepository.java
@@ -2,8 +2,15 @@ package org.sopt.collaboration.domain.club.repository;
 
 import org.sopt.collaboration.domain.club.entity.Club;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ClubRepository extends JpaRepository<Club, Long> {
+
+    @Query("SELECT c FROM Club c ORDER BY c.likeCount DESC")
+    List<Club> findAllSortedByLikes();
+
 }

--- a/src/main/java/org/sopt/collaboration/domain/club/repository/ClubRepository.java
+++ b/src/main/java/org/sopt/collaboration/domain/club/repository/ClubRepository.java
@@ -9,8 +9,5 @@ import java.util.List;
 
 @Repository
 public interface ClubRepository extends JpaRepository<Club, Long> {
-
-    @Query("SELECT c FROM Club c ORDER BY c.likeCount DESC")
-    List<Club> findAllSortedByLikes();
-
+    List<Club> findTop5ByOrderByLikeCountDesc();
 }

--- a/src/main/java/org/sopt/collaboration/domain/club/service/ClubService.java
+++ b/src/main/java/org/sopt/collaboration/domain/club/service/ClubService.java
@@ -14,12 +14,8 @@ import java.util.List;
 public class ClubService {
     private final ClubRepository clubRepository;
 
-    public List<ClubDto> getAllClubs(){
-        return clubRepository.findAll().stream().map(ClubDto::new).toList();
-    }
-
     public List<ClubDto> getClubsByLikesDesc(){
-        return clubRepository.findAllSortedByLikes()
+        return clubRepository.findTop5ByOrderByLikeCountDesc()
                 .stream()
                 .map(ClubDto::new)
                 .toList();

--- a/src/main/java/org/sopt/collaboration/domain/club/service/ClubService.java
+++ b/src/main/java/org/sopt/collaboration/domain/club/service/ClubService.java
@@ -1,0 +1,20 @@
+package org.sopt.collaboration.domain.club.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.collaboration.domain.club.dto.ClubDto;
+import org.sopt.collaboration.domain.club.repository.ClubRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClubService {
+    private final ClubRepository clubRepository;
+
+    public List<ClubDto> getAllClubs(){
+        return clubRepository.findAll().stream().map(ClubDto::new).toList();
+    }
+}

--- a/src/main/java/org/sopt/collaboration/domain/club/service/ClubService.java
+++ b/src/main/java/org/sopt/collaboration/domain/club/service/ClubService.java
@@ -17,4 +17,11 @@ public class ClubService {
     public List<ClubDto> getAllClubs(){
         return clubRepository.findAll().stream().map(ClubDto::new).toList();
     }
+
+    public List<ClubDto> getClubsByLikesDesc(){
+        return clubRepository.findAllSortedByLikes()
+                .stream()
+                .map(ClubDto::new)
+                .toList();
+    }
 }


### PR DESCRIPTION
## **Related issue**

closes #1 

## **Work Description**

- [x]  좋아요 순으로 동아리 목록을 내림차순 정렬하는 기능 구현
- [x]  `ClubController`에 `/club` GET 엔드포인트를 좋아요 순 정렬 조회용으로 설정. 
- [x] 전체 Club 조회 API 분리: `/club/all` GET 엔드포인트 추가하여 기존 전체 조회 기능 유지 `getClub()`

## Screen Shot 📸
|게시물 수정 기능|
|:--:|
![스크린샷 2025-05-13 오전 1 51 33](https://github.com/user-attachments/assets/8a10eeeb-7111-472b-9da8-d3005a3e5615)


## **To Reviewers**
- 현재의 코드가 비즈니스 로직과 데이터 접근 로직이 명확한지 궁금합니다.
- DTO 변환 생성자를 활용해 Entity 노출 없이 필요한 데이터만 제공하라고 조언해주신 부분처럼 객체 지향의 특징을 더 살릴 수 있는 부분이 있는지 궁금합니다.
- 좋아요 수에 따른 내림차수 정렬 메서드 이외에, 기본 findAll() 메서드도 남겨두었는데, 추후 확장성을 위해 남겨두는게 좋은지, 당장은 사용되지 않는 부분이기에 삭제하는게 적합한지 궁금합니다.