### PR TITLE
[FEAT] 공통 응답 및 예외처리 구현

### DIFF
--- a/src/main/java/org/sopt/collaboration/global/api/handler/ApiExceptionHandler.java
+++ b/src/main/java/org/sopt/collaboration/global/api/handler/ApiExceptionHandler.java
@@ -1,0 +1,39 @@
+package org.sopt.collaboration.global.api.handler;
+
+import org.sopt.collaboration.global.api.response.ErrorResponse;
+import org.sopt.collaboration.global.exception.GlobalException;
+import org.sopt.collaboration.global.exception.message.ExceptionMessage;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ApiExceptionHandler {
+	@ExceptionHandler(GlobalException.class)
+	public ResponseEntity<ErrorResponse> handleGlobalException(GlobalException e) {
+		ExceptionMessage exceptionMessage = e.getExceptionMessage();
+
+		return ResponseEntity
+			.status(exceptionMessage.getHttpStatus())
+			.body(ErrorResponse.of(e.getExceptionMessage()));
+	}
+
+	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+	public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException() {
+		ExceptionMessage exceptionMessage =ExceptionMessage.BAD_REQUEST;
+
+		return ResponseEntity
+			.status(exceptionMessage.getHttpStatus())
+			.body(ErrorResponse.of(exceptionMessage));
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ErrorResponse> handleUndefinedException(Exception e) {
+		ExceptionMessage exceptionMessage = ExceptionMessage.INTERNAL_SERVER_ERROR;
+
+		return ResponseEntity
+			.status(exceptionMessage.getHttpStatus())
+			.body(ErrorResponse.of(exceptionMessage));
+	}
+}

--- a/src/main/java/org/sopt/collaboration/global/api/handler/ApiResponseHandler.java
+++ b/src/main/java/org/sopt/collaboration/global/api/handler/ApiResponseHandler.java
@@ -1,0 +1,38 @@
+package org.sopt.collaboration.global.api.handler;
+
+import org.sopt.collaboration.global.api.message.ResponseMessage;
+import org.sopt.collaboration.global.api.response.ErrorResponse;
+import org.sopt.collaboration.global.api.response.SuccessfulResponse;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice
+public class ApiResponseHandler implements ResponseBodyAdvice<Object> {
+	@Override
+	public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+		return true;
+	}
+
+	@Override
+	public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
+		Class<? extends HttpMessageConverter<?>> selectedConverterType, ServerHttpRequest request,
+		ServerHttpResponse response) {
+
+		// 예외처리된 응답에 대한 상태코드 설정 및 apiResponse wrapping 생략
+		if (body instanceof ErrorResponse errorResponse) {
+			return body;
+		}
+
+		// 이미 응답 형태로 감싸진 경우 바로 body를 반환
+		if (body instanceof SuccessfulResponse) {
+			return body;
+		}
+
+		return SuccessfulResponse.of(ResponseMessage.SUCCESS, body);
+	}
+}

--- a/src/main/java/org/sopt/collaboration/global/api/message/ResponseMessage.java
+++ b/src/main/java/org/sopt/collaboration/global/api/message/ResponseMessage.java
@@ -1,0 +1,16 @@
+package org.sopt.collaboration.global.api.message;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ResponseMessage {
+	SUCCESS(HttpStatus.OK, "SUCCESS", "요청이 성공적으로 처리되었습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/org/sopt/collaboration/global/api/response/ApiResponse.java
+++ b/src/main/java/org/sopt/collaboration/global/api/response/ApiResponse.java
@@ -1,0 +1,19 @@
+package org.sopt.collaboration.global.api.response;
+
+public abstract class ApiResponse {
+	private final String code;
+	private final String message;
+
+	public ApiResponse(String code, String message) {
+		this.code = code;
+		this.message = message;
+	}
+
+	public String getCode() {
+		return this.code;
+	}
+
+	public String getMessage() {
+		return this.message;
+	}
+}

--- a/src/main/java/org/sopt/collaboration/global/api/response/ErrorResponse.java
+++ b/src/main/java/org/sopt/collaboration/global/api/response/ErrorResponse.java
@@ -1,0 +1,13 @@
+package org.sopt.collaboration.global.api.response;
+
+import org.sopt.collaboration.global.exception.message.ExceptionMessage;
+
+public class ErrorResponse extends ApiResponse {
+	public ErrorResponse(String code, String message) {
+		super(code, message);
+	}
+
+	public static ErrorResponse of(ExceptionMessage exceptionMessage) {
+		return new ErrorResponse(exceptionMessage.getCode(), exceptionMessage.getMessage());
+	}
+}

--- a/src/main/java/org/sopt/collaboration/global/api/response/SuccessfulResponse.java
+++ b/src/main/java/org/sopt/collaboration/global/api/response/SuccessfulResponse.java
@@ -1,0 +1,20 @@
+package org.sopt.collaboration.global.api.response;
+
+import org.sopt.collaboration.global.api.message.ResponseMessage;
+
+public class SuccessfulResponse<T> extends ApiResponse {
+	private final T data;
+
+	public SuccessfulResponse(String code, String message, T data) {
+		super(code, message);
+		this.data = data;
+	}
+
+	public static <T> SuccessfulResponse<T> of(ResponseMessage responseMessage, T data) {
+		return new SuccessfulResponse<T>(responseMessage.getCode(), responseMessage.getMessage(), data);
+	}
+
+	public T getData() {
+		return this.data;
+	}
+}

--- a/src/main/java/org/sopt/collaboration/global/exception/GlobalException.java
+++ b/src/main/java/org/sopt/collaboration/global/exception/GlobalException.java
@@ -1,0 +1,15 @@
+package org.sopt.collaboration.global.exception;
+
+import org.sopt.collaboration.global.exception.message.ExceptionMessage;
+
+public class GlobalException extends RuntimeException {
+	private final ExceptionMessage exceptionMessage;
+
+	public GlobalException(ExceptionMessage exceptionMessage) {
+		this.exceptionMessage = exceptionMessage;
+	}
+
+	public ExceptionMessage getExceptionMessage() {
+		return this.exceptionMessage;
+	}
+}

--- a/src/main/java/org/sopt/collaboration/global/exception/message/ExceptionMessage.java
+++ b/src/main/java/org/sopt/collaboration/global/exception/message/ExceptionMessage.java
@@ -1,0 +1,18 @@
+package org.sopt.collaboration.global.exception.message;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExceptionMessage {
+	BAD_REQUEST(HttpStatus.METHOD_NOT_ALLOWED, "FAILURE", "잘못된 HTTP method 요청입니다."),
+	INVALID_TAG_NAME(HttpStatus.BAD_REQUEST, "FAILURE", "잘못된 검색조건입니다."),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "ERROR", "서버 내부 오류입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}


### PR DESCRIPTION
## **Related issue**

closes #5 

## **Work Description**

- [x]  공통 응답 형태 구현
- [x] 공통 응답 처리 구현
- [x] 예외 응답 형태 구현
- [x] 예외 응답 처리 구현

## **To Reviewers**

- 아직 완성된 API가 없어 테스트는 진행되지 않았으며, merge후에 api구현 완료시 테스트 예정입니다.
- 컨트롤러에서 `ResponseEntity`로 감싼 형태가 아닌 DTO만 반환하면 됩니다.
- 패키지 구조 및 내부 로직에 대해 API개발 완료 후에 리팩토링 진행할 예정입니다.