### PR TITLE
[FEAT] 인기 동아리 조회 기능 구현

### DIFF
--- a/src/main/java/org/sopt/collaboration/domain/clubRecruit/controller/ClubRecruitController.java
+++ b/src/main/java/org/sopt/collaboration/domain/clubRecruit/controller/ClubRecruitController.java
@@ -14,7 +14,7 @@ import java.util.List;
 public class ClubRecruitController {
     private final ClubRecruitService clubRecruitService;
 
-    @GetMapping("/club/popular")
+    @GetMapping("/clubs/popular")
     public ResponseEntity<List<ClubRecruitDto>> getClubRecruitByViewCount() {
         List<ClubRecruitDto> clubRecruit = clubRecruitService.getClubRecruitByViewCount();
         return ResponseEntity.ok(clubRecruit);

--- a/src/main/java/org/sopt/collaboration/domain/clubRecruit/controller/ClubRecruitController.java
+++ b/src/main/java/org/sopt/collaboration/domain/clubRecruit/controller/ClubRecruitController.java
@@ -1,0 +1,22 @@
+package org.sopt.collaboration.domain.clubRecruit.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.collaboration.domain.clubRecruit.dto.ClubRecruitDto;
+import org.sopt.collaboration.domain.clubRecruit.service.ClubRecruitService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class ClubRecruitController {
+    private final ClubRecruitService clubRecruitService;
+
+    @GetMapping("/club/popular")
+    public ResponseEntity<List<ClubRecruitDto>> getClubRecruitByViewCount() {
+        List<ClubRecruitDto> clubRecruit = clubRecruitService.getClubRecruitByViewCount();
+        return ResponseEntity.ok(clubRecruit);
+    }
+}

--- a/src/main/java/org/sopt/collaboration/domain/clubRecruit/dto/ClubRecruitDto.java
+++ b/src/main/java/org/sopt/collaboration/domain/clubRecruit/dto/ClubRecruitDto.java
@@ -22,6 +22,7 @@ public class ClubRecruitDto {
 
     public ClubRecruitDto(ClubRecruit clubRecruit) {
         this.title = clubRecruit.getTitle();
+        this.recruitDeadline = clubRecruit.getRecruitDeadline();
         this.viewCount = clubRecruit.getViewCount();
         this.commentCount = clubRecruit.getCommentCount();
         this.image = clubRecruit.getImage();

--- a/src/main/java/org/sopt/collaboration/domain/clubRecruit/dto/ClubRecruitDto.java
+++ b/src/main/java/org/sopt/collaboration/domain/clubRecruit/dto/ClubRecruitDto.java
@@ -1,0 +1,30 @@
+package org.sopt.collaboration.domain.clubRecruit.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.collaboration.domain.club.dto.ClubDto;
+import org.sopt.collaboration.domain.club.entity.Club;
+import org.sopt.collaboration.domain.club.entity.ClubRecruit;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class ClubRecruitDto {
+    private Long id;
+    private String title;
+    private int viewCount;
+    private int commentCount;
+    private LocalDate recruitDeadline;
+    private String image;
+    private LocalDate createdDate;
+    private long club;
+
+    public ClubRecruitDto(ClubRecruit clubRecruit) {
+        this.title = clubRecruit.getTitle();
+        this.viewCount = clubRecruit.getViewCount();
+        this.commentCount = clubRecruit.getCommentCount();
+        this.image = clubRecruit.getImage();
+        this.club = clubRecruit.getClub().getId();
+    }
+}

--- a/src/main/java/org/sopt/collaboration/domain/clubRecruit/repository/ClubRecruitRepository.java
+++ b/src/main/java/org/sopt/collaboration/domain/clubRecruit/repository/ClubRecruitRepository.java
@@ -1,0 +1,12 @@
+package org.sopt.collaboration.domain.clubRecruit.repository;
+
+import org.sopt.collaboration.domain.club.entity.ClubRecruit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ClubRecruitRepository extends JpaRepository<ClubRecruit, Long> {
+    List<ClubRecruit> findTop5ByOrderByViewCountDesc();
+}

--- a/src/main/java/org/sopt/collaboration/domain/clubRecruit/service/ClubRecruitService.java
+++ b/src/main/java/org/sopt/collaboration/domain/clubRecruit/service/ClubRecruitService.java
@@ -1,0 +1,25 @@
+package org.sopt.collaboration.domain.clubRecruit.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.collaboration.domain.clubRecruit.dto.ClubRecruitDto;
+import org.sopt.collaboration.domain.clubRecruit.repository.ClubRecruitRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClubRecruitService {
+    private final ClubRecruitRepository clubRecruitRepository;
+
+    public List<ClubRecruitDto> getClubRecruitByViewCount() {
+        return clubRecruitRepository.findTop5ByOrderByViewCountDesc()
+                .stream()
+                .map(ClubRecruitDto::new)
+                .toList();
+    }
+}


### PR DESCRIPTION
## **Related issue**

closes #8 

## **Work Description**

- [x]  viewCount(조회수) 기준 상위 5개 정렬하는 기능

## Screen Shot 📸
|인기 동아리 조회 기능|
|:--:|
![스크린샷 2025-05-14 오전 12 04 06](https://github.com/user-attachments/assets/278c6492-0254-478f-9688-3a631233ccb5)

## **To Reviewers**

- `ClubRecruit`의 Entity 부분에서 `club`필드 자체를 받아오려 했으나,객체를 JSON으로 직렬화 할 때, ByteBuddyInterceptor 오류로 인해 500에러가 발생함을 알 수 있었습니다. 어쩔 수 없이, club에서 필요한 정보만 꺼내오는 방식으로 구현해서 오류를 해결했는데, 맞게 한건지 궁금합니다!