### PR TITLE
[FEAT] 대외활동 모집글 조회 구현

### DIFF
--- a/src/main/java/org/sopt/collaboration/domain/activity/controller/ActivityController.java
+++ b/src/main/java/org/sopt/collaboration/domain/activity/controller/ActivityController.java
@@ -1,0 +1,23 @@
+package org.sopt.collaboration.domain.activity.controller;
+
+import java.util.List;
+
+import org.sopt.collaboration.domain.activity.dto.ActivityRecruitResponse;
+import org.sopt.collaboration.domain.activity.service.ActivityService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(path = "/api/v1/activities")
+public class ActivityController {
+	private final ActivityService activityService;
+
+	@GetMapping(path = "/popular")
+	public List<ActivityRecruitResponse> getPopularActivities() {
+		return activityService.getPopularActivities();
+	}
+}

--- a/src/main/java/org/sopt/collaboration/domain/activity/dto/ActivityRecruitResponse.java
+++ b/src/main/java/org/sopt/collaboration/domain/activity/dto/ActivityRecruitResponse.java
@@ -1,0 +1,14 @@
+package org.sopt.collaboration.domain.activity.dto;
+
+import org.sopt.collaboration.domain.activity.entity.ActivityRecruit;
+
+public record ActivityRecruitResponse(String title, int viewCount, int commentCount, String image) {
+
+	public static ActivityRecruitResponse from(ActivityRecruit activityRecruit) {
+		return new ActivityRecruitResponse(
+			activityRecruit.getTitle(),
+			activityRecruit.getViewCount(),
+			activityRecruit.getCommentCount(),
+			activityRecruit.getImage());
+	}
+}

--- a/src/main/java/org/sopt/collaboration/domain/activity/entity/ActivityRecruit.java
+++ b/src/main/java/org/sopt/collaboration/domain/activity/entity/ActivityRecruit.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -38,4 +39,13 @@ public class ActivityRecruit {
 	@CreatedDate
 	@Column(name = "created_date", nullable = false)
 	private LocalDate createdDate;
+
+	@Builder
+	private ActivityRecruit(String title, int viewCount, int commentCount, String image, LocalDate createdDate) {
+		this.title = title;
+		this.viewCount = viewCount;
+		this.commentCount = commentCount;
+		this.image = image;
+		this.createdDate = createdDate;
+	}
 }

--- a/src/main/java/org/sopt/collaboration/domain/activity/repository/ActivityRepository.java
+++ b/src/main/java/org/sopt/collaboration/domain/activity/repository/ActivityRepository.java
@@ -1,0 +1,12 @@
+package org.sopt.collaboration.domain.activity.repository;
+
+import java.util.List;
+
+import org.sopt.collaboration.domain.activity.entity.ActivityRecruit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ActivityRepository extends JpaRepository<ActivityRecruit, Long> {
+	List<ActivityRecruit> findTop5ByOrderByViewCountDesc();
+}

--- a/src/main/java/org/sopt/collaboration/domain/activity/service/ActivityService.java
+++ b/src/main/java/org/sopt/collaboration/domain/activity/service/ActivityService.java
@@ -1,0 +1,24 @@
+package org.sopt.collaboration.domain.activity.service;
+
+import java.util.List;
+
+import org.sopt.collaboration.domain.activity.dto.ActivityRecruitResponse;
+import org.sopt.collaboration.domain.activity.repository.ActivityRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ActivityService {
+	private final ActivityRepository activityRepository;
+
+	public List<ActivityRecruitResponse> getPopularActivities() {
+		return activityRepository.findTop5ByOrderByViewCountDesc()
+			.stream()
+			.map(ActivityRecruitResponse::from)
+			.toList();
+	}
+}


### PR DESCRIPTION
## **Related issue**

closes #6 

## **Work Description**

- [x] 인기 대외활동 모집글 조회 구현
- [x] 조회수 기준으로 정렬 후 상위 5개의 결과만 반환하도록 적용

## **To Reviewers**

- 생각해보니 `id`필드를 추가하는 것이 좋을 것 같네요...